### PR TITLE
Restart only single container when there are updates to docker-compose.yml

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,6 +81,10 @@ them prior to restarting.
 It also cleanly stops and removes the containers. This
 is important because `hsl-map-server` cannot be stopped and restarted.
 
+**Restarting a single digitransit container**
+
+`restart-digitransit-container digitransit-ui`
+
 **Viewing logs**
 
 All logs are sent to `journald` for storage and automatic deletion. Here is

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -48,6 +48,7 @@ certbot_auto_renew_minute: "2"
 certbot_auto_renew_hour: "0"
 
 map_url: "https://tiles.stadtnavi.eu/streets/{z}/{x}/{y}{r}.png"
+semi_transparent_map_url: "https://tiles.stadtnavi.eu/satellite-overlay/{z}/{x}/{y}{r}.png"
 
 # the docker tag/sha used to build containers and run OTP itself in the digitransit docker-compose
 # cluster

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -47,8 +47,8 @@ certbot_admin_email: mail@leonard.io
 certbot_auto_renew_minute: "2"
 certbot_auto_renew_hour: "0"
 
-map_url: "https://tiles.stadtnavi.eu/streets/{z}/{x}/{y}{r}.png"
-semi_transparent_map_url: "https://tiles.stadtnavi.eu/satellite-overlay/{z}/{x}/{y}{r}.png"
+map_url: "https://api.maptiler.com/maps/c3e8e9d6-1155-4329-80f3-6c03a2bcc7a4/256/{z}/{x}/{y}{r}.png?key=eA0drARBA1uPzLR6StGD"
+semi_transparent_map_url: "https://api.maptiler.com/maps/ffa4d49e-c68c-46c8-ab3f-60543337cecb/256/{z}/{x}/{y}.png?key=eA0drARBA1uPzLR6StGD"
 
 # the docker tag/sha used to build containers and run OTP itself in the digitransit docker-compose
 # cluster

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -47,7 +47,7 @@ certbot_admin_email: mail@leonard.io
 certbot_auto_renew_minute: "2"
 certbot_auto_renew_hour: "0"
 
-map_url: "https://api.maptiler.com/maps/c3e8e9d6-1155-4329-80f3-6c03a2bcc7a4/256/{z}/{x}/{y}{r}.png?key=eA0drARBA1uPzLR6StGD"
+map_url: "https://tiles.stadtnavi.eu/streets/{z}/{x}/{y}{r}.png"
 
 # the docker tag/sha used to build containers and run OTP itself in the digitransit docker-compose
 # cluster

--- a/group_vars/production.yml
+++ b/group_vars/production.yml
@@ -10,7 +10,7 @@ digitransit:
     proxy: lehrenfried/digitransit-proxy:post-migration
     otp: mfdz/opentripplanner:{{ otp_docker_tag }}
     data_container: mfdz/opentripplanner-data-container-hb:local
-    ui: stadtnavi/digitransit-ui:2960e01429c5a3e00d608c7c7488824fcce9b6e5
+    ui: stadtnavi/digitransit-ui:e2f82f332b9e245eb88a417a7419202c8d8c1e1b
     map_server: mfdz/hsl-map-server:688564327
 
 hostname: herrenberg.stadtnavi.de

--- a/group_vars/staging.yml
+++ b/group_vars/staging.yml
@@ -7,6 +7,9 @@ api_hostname: api.mih.mitfahren-bw.de
 matomo_hostname: track.mfdz.de
 photon_hostname: photon-temp.leonard.io
 
+map_url: "https://tiles.stadtnavi.eu/streets/{z}/{x}/{y}{r}.png"
+semi_transparent_map_url: "https://tiles.stadtnavi.eu/satellite-overlay/{z}/{x}/{y}{r}.png"
+
 matomo_url: https://track.mfdz.de/js/container_TeHZVOVk_staging_a1a89f1a01da974800990125.js
 
 mfdz_gtfs_url: !vault |
@@ -52,5 +55,3 @@ matomo_db_root_password: !vault |
           64386237323337623061336466343066393232633638646538336162373631323839383635303562
           6138626538356638663630303966353739316135656162613465
 
-install_photon: False
-install_tilemaker: True

--- a/group_vars/staging.yml
+++ b/group_vars/staging.yml
@@ -7,8 +7,6 @@ api_hostname: api.mih.mitfahren-bw.de
 matomo_hostname: track.mfdz.de
 photon_hostname: photon-temp.leonard.io
 
-docker_prune_max_age: 36h
-
 matomo_url: https://track.mfdz.de/js/container_TeHZVOVk_staging_a1a89f1a01da974800990125.js
 
 mfdz_gtfs_url: !vault |

--- a/roles/digitransit/handlers/main.yml
+++ b/roles/digitransit/handlers/main.yml
@@ -4,7 +4,5 @@
     name: nginx
     state: restarted
 
-- name: Restart digitransit
-  service:
-    name: digitransit-docker-compose
-    state: restarted
+- name: Restart digitransit-ui
+  command: restart-digitransit-container digitransit-ui

--- a/roles/digitransit/tasks/main.yml
+++ b/roles/digitransit/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
 - name: Create digitransit config directory
   file:
-    path: /etc/digitransit
+    path: "{{ item }}"
     state: directory
     owner: root
     group: root
     mode: 0775
+  with_items:
+    - /etc/digitransit
+    - /etc/digitransit/versions
 
 - name: Create tile cache directory
   file:
@@ -17,7 +20,17 @@
 
 - name: Install docker-compose file
   template: src=docker-compose.yml dest=/etc/digitransit/docker-compose.yml
-  notify: Restart digitransit
+
+- name: Copy container restart script
+  template:
+    src: restart-digitransit-container
+    dest: /usr/local/bin/
+    mode: a+x
+
+- name: Install version file
+  copy:
+    content: "{{ digitransit['images']['ui'] }}"
+    dest: /etc/digitransit/versions/digitransit-ui
 
 - name: Install service file for digitransit-docker-compose
   template: src=digitransit-docker-compose.service dest=/etc/systemd/system/

--- a/roles/digitransit/tasks/main.yml
+++ b/roles/digitransit/tasks/main.yml
@@ -17,14 +17,15 @@
     group: www-data
     mode: 0775
 
-- name: Install docker-compose file
-  template: src=docker-compose.yml dest=/etc/digitransit/docker-compose.yml
-
 - name: Copy container restart script
   template:
     src: restart-digitransit-container
     dest: /usr/local/bin/
     mode: a+x
+
+- name: Install docker-compose file
+  template: src=docker-compose.yml dest=/etc/digitransit/docker-compose.yml
+  notify: Restart digitransit-ui
 
 - name: Install service file for digitransit-docker-compose
   template:

--- a/roles/digitransit/tasks/main.yml
+++ b/roles/digitransit/tasks/main.yml
@@ -33,8 +33,9 @@
     dest: /etc/digitransit/versions/digitransit-ui
 
 - name: Install service file for digitransit-docker-compose
-  template: src=digitransit-docker-compose.service dest=/etc/systemd/system/
-  #notify: Restart digitransit
+  template:
+    src: digitransit-docker-compose.service
+    dest: /etc/systemd/system/
 
 - name: Start digitransit
   systemd:

--- a/roles/digitransit/tasks/main.yml
+++ b/roles/digitransit/tasks/main.yml
@@ -8,7 +8,6 @@
     mode: 0775
   with_items:
     - /etc/digitransit
-    - /etc/digitransit/versions
 
 - name: Create tile cache directory
   file:
@@ -26,11 +25,6 @@
     src: restart-digitransit-container
     dest: /usr/local/bin/
     mode: a+x
-
-- name: Install version file
-  copy:
-    content: "{{ digitransit['images']['ui'] }}"
-    dest: /etc/digitransit/versions/digitransit-ui
 
 - name: Install service file for digitransit-docker-compose
   template:

--- a/roles/digitransit/templates/docker-compose.yml
+++ b/roles/digitransit/templates/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - GEOCODING_BASE_URL=https://{{ api_hostname }}/geocoding/v1
       - API_URL=https://{{ api_hostname }}
       - MAP_URL={{ map_url }}
+      - SEMI_TRANSPARENT_MAP_URL={{ semi_transparent_map_url }}
       - MATOMO_URL={{ matomo_url }}
       - NODE_ENV=production
       - FAHRGEMEINSCHAFT_API_KEY={{ fahrgemeinschaft_api_key }}

--- a/roles/digitransit/templates/docker-compose.yml
+++ b/roles/digitransit/templates/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3'
 
+
 services:
   digitransit-proxy:
     image: {{ digitransit["images"]["proxy"] }}

--- a/roles/digitransit/templates/restart-digitransit-container
+++ b/roles/digitransit/templates/restart-digitransit-container
@@ -4,5 +4,5 @@ CONTAINER_NAME=$1
 
 cd /etc/digitransit
 docker-compose pull
-echo "🗃️ Restarting single digitransit container '$1' on {{ inventory_hostname }} 🗃️" | send-to-matrix
+echo "🗃️ Restarting digitransit container '$1' on {{ inventory_hostname }} 🗃️" | send-to-matrix
 docker-compose up -d --no-deps $CONTAINER_NAME

--- a/roles/digitransit/templates/restart-digitransit-container
+++ b/roles/digitransit/templates/restart-digitransit-container
@@ -4,5 +4,5 @@ CONTAINER_NAME=$1
 
 cd /etc/digitransit
 docker-compose pull
-echo "🗃️ Restarting digitransit container '$1' on {{ inventory_hostname }} 🗃️" | send-to-matrix
+send-to-matrix "🗃️ Restarting digitransit container '$1' on {{ inventory_hostname }}"
 docker-compose up -d --no-deps $CONTAINER_NAME

--- a/roles/digitransit/templates/restart-digitransit-container
+++ b/roles/digitransit/templates/restart-digitransit-container
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+cd /etc/digitransit
+docker-compose pull
+echo "🗃️ Restarting single digitransit container '$1' on {{ inventory_hostname }} 🗃️" | send-to-matrix
+docker-compose up -d --no-deps $1

--- a/roles/digitransit/templates/restart-digitransit-container
+++ b/roles/digitransit/templates/restart-digitransit-container
@@ -1,6 +1,8 @@
 #! /bin/bash
 
+CONTAINER_NAME=$1
+
 cd /etc/digitransit
 docker-compose pull
 echo "🗃️ Restarting single digitransit container '$1' on {{ inventory_hostname }} 🗃️" | send-to-matrix
-docker-compose up -d --no-deps $1
+docker-compose up -d --no-deps $CONTAINER_NAME


### PR DESCRIPTION
This is achieved with the command `restart-digitransit-container digitransit-ui`. That would also work for other containers in the docker-compose cluster.

I've also reconfigured the tiles again to point to tiles.stadtnavi.eu.
