### PR TITLE
added opacity for corresponding constructions

### DIFF
--- a/roles/tileserver/templates/satellite-overlay.json
+++ b/roles/tileserver/templates/satellite-overlay.json
@@ -2143,6 +2143,7 @@
       "metadata": {},
       "paint": {
         "line-color": "#fea",
+        "line-opacity": 0.2,
         "line-dasharray": [
           2,
           2


### PR DESCRIPTION
## Proposed changes
  - added opacity for corresponding constructions

Before: 
![image](https://user-images.githubusercontent.com/54352878/87925923-48408000-ca81-11ea-94dc-417adbba5331.png)

After:
![image](https://user-images.githubusercontent.com/54352878/87925965-52fb1500-ca81-11ea-81d6-5b33c943511b.png)

closes #35 
