### PR TITLE
Satellite fix - rivers

### DIFF
--- a/roles/tileserver/templates/satellite-overlay.json
+++ b/roles/tileserver/templates/satellite-overlay.json
@@ -39,7 +39,7 @@
       "id": "waterway_tunnel",
       "layout": {
         "line-cap": "round",
-        "visibility": "visible"
+        "visibility": "none"
       },
       "minzoom": 14,
       "paint": {
@@ -88,7 +88,7 @@
       "id": "waterway_river",
       "layout": {
         "line-cap": "round",
-        "visibility": "visible"
+        "visibility": "none"
       },
       "metadata": {},
       "paint": {
@@ -132,7 +132,8 @@
       ],
       "id": "waterway_river_intermittent",
       "layout": {
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "none"
       },
       "metadata": {},
       "paint": {
@@ -181,7 +182,7 @@
       "id": "waterway_other",
       "layout": {
         "line-cap": "round",
-        "visibility": "visible"
+        "visibility": "none"
       },
       "metadata": {},
       "paint": {
@@ -226,7 +227,7 @@
       "id": "waterway_other_intermittent",
       "layout": {
         "line-cap": "round",
-        "visibility": "visible"
+        "visibility": "none"
       },
       "metadata": {},
       "paint": {


### PR DESCRIPTION
## Proposed changes
  - removed unnecessary river lines from satellite map mode
  - we thought that river and channel indicators are ugly because it looks like they are on top of buildings
  - it wasn't requested so only merge it if you like the changes 
  - we checked Google Maps, they don't display them either

Google Maps:
![Screenshot_2020-08-04_11-30-52](https://user-images.githubusercontent.com/54352878/89282285-98a40a00-d64b-11ea-84db-3c1f1550a059.png)

Stadtnavi:
![Screenshot_2020-08-04_11-31-27](https://user-images.githubusercontent.com/54352878/89282334-a9ed1680-d64b-11ea-93e4-a133f4c8be4d.png)
![Screenshot_2020-08-04_12-12-48](https://user-images.githubusercontent.com/54352878/89282448-d7d25b00-d64b-11ea-8dfc-c1b21f4dd1fd.png)
