### PR TITLE
expose delay-prediction-service:3000 as /gtfs-rt

### DIFF
--- a/roles/delay-prediction-service/templates/delay-prediction-service
+++ b/roles/delay-prediction-service/templates/delay-prediction-service
@@ -23,6 +23,7 @@ docker run --rm -i \
     -e PGPASSWORD="{{ delay_postgres_password }}" \
     -e PGDATABASE="{{ delay_postgres_db }}" \
     -e LOG_LEVEL=debug \
+    -p {{ delay_prediction_service_port }}:3000
     --name ${CONTAINER_NAME} \
     ${DOCKER_IMAGE} \
     $@

--- a/roles/digitransit/defaults/main.yml
+++ b/roles/digitransit/defaults/main.yml
@@ -3,3 +3,4 @@ otp_port: 8080
 map_server_port: 9090
 graphiql_port: 9091
 fares_service_port: 9092
+delay_prediction_service_port: 9093

--- a/roles/digitransit/templates/nginx-site-api.conf
+++ b/roles/digitransit/templates/nginx-site-api.conf
@@ -106,4 +106,14 @@ server {
 
     proxy_pass http://localhost:1883;
   }
+
+  location /gtfs-rt {
+    rewrite ^/gtfs-rt(.*) /$1 break;
+
+    proxy_pass         http://127.0.0.1:{{ delay_prediction_service_port }}$uri$is_args$args;
+
+    add_header 'Access-Control-Allow-Origin' '*';
+    include /etc/nginx/proxy_headers.conf;
+    include /etc/nginx/cors.conf;
+  }
 }


### PR DESCRIPTION
So that the (full) GTFS-Realtime feed can be accessed via HTTP as well.