### PR TITLE
Switch to new container on track.dev.stadtnavi.eu

### DIFF
--- a/group_vars/dev.yml
+++ b/group_vars/dev.yml
@@ -28,7 +28,7 @@ api_hostname: api.dev.stadtnavi.eu
 dt_api_hostname: "{{api_hostname}}"
 
 matomo_hostname: track.dev.stadtnavi.eu
-matomo_url: https://track.stadtnavi.de/js/container_uzMuZE7B.js
+matomo_url: https://track.dev.stadtnavi.eu/js/container_T70NE3DF.js
 
 certbot_certs:
   - domains:


### PR DESCRIPTION
This PR changes the matomo container URL for dev to the dev container's ID.

Note: the matomo configuration is now version managed in https://github.com/stadtnavi/stadtnavi-matomo