### PR TITLE
Update ifopt script

### DIFF
--- a/roles/photon/tasks/main.yml
+++ b/roles/photon/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install base packages
   package:
     name:
-      - python3-psycopg2
+      - python3-psycopg
     state: present
 
 - name: Create nominatim config directory

--- a/roles/photon/templates/nominatim_add_ifopt.py
+++ b/roles/photon/templates/nominatim_add_ifopt.py
@@ -4,34 +4,35 @@ Add missing PT information to a Nominatim database.
 
 The script expects a CSV file with the following fields:
 
- * Landkreis  - address county
- * Gemeinde   - address city
- * Ortsteil   - address district
+ * Landkreis  - (optional) address county
+ * Gemeinde   - (optional) address city
+ * Ortsteil   - (optional) address district
  * Haltestelle - name
  * Haltestelle_lang - alt_name
- * globaleID - IFOPT ID
- * lat, lon  - Geographic location
+ * GlobaleId - IFOPT ID
+ * zhv_lat, zhv_lon  - Geographic location
  * osm_id    - OSM id of the form <nwr><id>
+ * match_state - (optional) Kind of match.
 
 For each field, the script first tries to find the corresponding OSM object
 in the Nominatim database and add the ifopt, if necessary. If no object
 is found or there was no matching OSM object available in the first place,
-then an artifical object is added using the name, address and position
+then an artificial object is added using the name, address and position
 information from the CSV.
 
 To use the script in on an existing Photon export with updates:
 
-Initialisation:
- * Run script against the Nominatim database using '-i' parameter to force
-   an invalidation of all objects.
+ * Make sure Photon is set up for updates (see -nominatim-update-init-for)
+ * (Updates only) run OSM update on Nominatim database.
+ * Run script against the Nominatim database.
+ * Run address processing: nominatim index
  * Run photon update script.
 
-On Updates:
- * Run OSM update on Nominatim database.
- * Run script against the Nominatim database without '-i' parameter.
- * Run photon update script.
+If you want to force all involved stops to be reindexed and reimported into
+Photon, run this scripts with '-i'. This is only necessary in the rare case
+when the Nominatim and Photon database seem to be out of sync for some reason.
+
 """
-
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from collections import Counter
 import csv
@@ -39,20 +40,10 @@ import gzip
 import logging
 import sys
 
-import psycopg2
-import psycopg2.extras
+import psycopg
+import psycopg.types.hstore
 
 LOG = logging.getLogger()
-
-def connect(args):
-    """ Create a connection from the given command line arguments.
-    """
-    conn = psycopg2.connect(dbname=args.database, user=args.username,
-                            host=args.host, port=args.port, password=args.password)
-
-    psycopg2.extras.register_hstore(conn)
-
-    return conn
 
 
 def get_parser():
@@ -83,10 +74,18 @@ def get_parser():
     return parser
 
 # OSM node ID guaranteed not to clash with OSM internal IDs in the next ten years.
-MIN_CUSTOM_ID = 10000000000
+MIN_CUSTOM_ID = 50000000000
+# Mapping of rows onto address details.
+# Presence of the rows is still optional, so feel free to add rows that only
+#  present in some of the CSV data.
+ADDRESS_MAPPING = [('Landkreis', 'county'),
+                   ('Gemeinde', 'city'),
+                   ('Ortsteil', 'suburb')]
+# Match types where to just drop the entire line
+MATCH_DROP = ('NO_MATCH_AND_SEEMS_UNSERVED', 'MATCHED_THOUGH_DISTANT')
 
 
-def insert_ifopt(conn, osm_id, ifopt, invalidate):
+def insert_ifopt(conn, osm_id, ifopt, names, invalidate):
     """ Add the given IFOPT id to the extratags of the given OSM object.
         When invalidate is set, the status of the OSM object is set to
         needing an update. That forces, for example, a reimport into Photon.
@@ -100,20 +99,37 @@ def insert_ifopt(conn, osm_id, ifopt, invalidate):
     osm_obj_id = int(osm_id[1:])
 
     update_sql = """UPDATE placex
-                        SET extratags = extratags || hstore ('ref:IFOPT', %s)"""
+                    SET extratags = coalesce(extratags, ''::hstore) || hstore ('ref:IFOPT', %(ifopt)s), """
     if invalidate:
-        update_sql += ", indexed_status = 2"
-    update_sql += "WHERE osm_type = %s and osm_id = %s"
+        update_sql += "indexed_status = 2"
+    else:
+        update_sql += "indexed_status = CASE WHEN extratags->'ref:IFOPT' = %(ifopt)s THEN 0 ELSE 2 END"
+    update_sql += """ WHERE osm_type = %(osm_type)s and osm_id = %(osm_id)s
+                      RETURNING name
+                  """
 
     with conn.cursor() as cur:
-        cur.execute(update_sql, (ifopt, osm_type, osm_obj_id))
-        return cur.rowcount > 0
+        cur.execute(update_sql,
+                    {'ifopt': ifopt, 'osm_type': osm_type, 'osm_id': osm_obj_id})
+        for row in cur:
+            osm_names = row[0]
+            if osm_names is not None:
+                return True
+            break
+        else:
+            return False
+
+        # Name missing in OSM so add the external one.
+        cur.execute("""UPDATE placex SET name = %s, indexed_status = 2
+                       WHERE osm_type = %s and osm_id = %s
+                    """, (names, osm_type, osm_obj_id))
+        return True
 
 
-def update_artificial(conn, node_id, names, address, extratags, lon, lat):
+def update_artificial(conn, node_id, names, address, extratags, lon, lat, invalidate):
     """ Update an existing artificial node with new information, if necessary.
     """
-    with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute("""SELECT place_id, name, address, extratags,
                               ST_X(geometry) as lon, ST_Y(geometry) as lat
                        FROM placex
@@ -122,13 +138,13 @@ def update_artificial(conn, node_id, names, address, extratags, lon, lat):
 
         row = cur.fetchone()
 
-        if not set(names.items()).issubset(set(row['name'].items())) \
+        if invalidate or not set(names.items()).issubset(set(row['name'].items())) \
            or set(row['address'].items()) != set(address.items()) \
            or row['extratags'].get('ref:IFOPT', '') != extratags['ref:IFOPT'] \
            or abs(row['lat'] - lat) > 0.000001 or abs(row['lon'] - lon) > 0.000001:
             cur.execute("""UPDATE placex
                            SET name = %s, address = %s, extratags = %s,
-                               geometry='SRID=4326;POINT(%s %s)',
+                               geometry=ST_SetSRID(ST_MakePoint(%s, %s), 4326),
                                indexed_status = 2
                            WHERE place_id = %s
                     """,
@@ -146,14 +162,27 @@ def insert_artificial(conn, node_id, names, address, extratags, lon, lat):
                                            geometry)
                        VALUES (nextval('seq_place'), 'N', %s,
                                'public_transport', 'stop', %s, %s, %s,
-                               'SRID=4326;POINT(%s %s)')
+                               ST_SetSRID(ST_MakePoint(%s, %s), 4326))
                     """, (node_id, names, address, extratags, lon, lat))
+
+
+def get_existing_externals(conn):
+    """ Get the set of current external IFOPT nodes, so we know if to update
+        or insert.
+    """
+    with conn.cursor() as cur:
+        cur.execute("""SELECT osm_id, extratags->'ref:IFOPT' as ifopt FROM placex
+                       WHERE osm_type = 'N' and osm_id >= %s
+                             and extratags ? 'ref:IFOPT'""",
+                    (MIN_CUSTOM_ID, ))
+        return {row[1] : row[0] for row in cur}
 
 
 def import_pt(conn, csvfile, invalidate):
     """ Read the given CSV file of PT stops and apply it to the Nominatim
-        database behind conneciton 'conn'. If 'invalidate' is set, then
-        an update will be forced on the OSM objects, where the ref:IFOPT is set.
+        database behind connection 'conn'. If 'write_update_table' is set, then
+        the IDs of changed objects will be written into the update tables of
+        Photon, so that it can update itself later.
     """
     reader = csv.DictReader(csvfile, delimiter=',')
 
@@ -161,23 +190,20 @@ def import_pt(conn, csvfile, invalidate):
     external_added = 0
     external_updated = 0
 
-    # Get the set of current external IFOPT nodes, so we know if to update
-    # or insert.
-    with conn.cursor() as cur:
-        cur.execute("""SELECT osm_id, extratags->'ref:IFOPT' FROM placex
-                       WHERE osm_type = 'N' and osm_id >= %s
-                             and extratags ? 'ref:IFOPT'""",
-                    (MIN_CUSTOM_ID, ))
-        extra_ifopts = {row[1] : row[0] for row in cur}
-
+    extra_ifopts = get_existing_externals(conn)
     current_ext_id = max(extra_ifopts.values(), default=MIN_CUSTOM_ID) + 1
-
     done_external_ifopts = set()
 
     for row in reader:
+        if row.get('match_state') in MATCH_DROP:
+            continue
+
         osm_id = row['osm_id']
-        ifopt = row['globaleID']
-        if osm_id and insert_ifopt(conn, osm_id, ifopt, invalidate):
+        ifopt = row['GlobaleId']
+        names = {'name': row['Haltestelle']}
+        if row['Haltestelle'] != row['Haltestelle_lang']:
+            names['name:alt'] = row['Haltestelle_lang']
+        if osm_id and insert_ifopt(conn, osm_id, ifopt, names, invalidate):
             osm_matched += 1
             continue
 
@@ -185,18 +211,15 @@ def import_pt(conn, csvfile, invalidate):
         if ifopt in done_external_ifopts:
             continue # ignore duplicates
 
-        lat = float(row['lat'])
-        lon = float(row['lon'])
-        address = {'county' : row['Landkreis'],
-                   'city' : row['Gemeinde'],
-                   'suburb': row['Ortsteil']}
-        names = {'name': row['Haltestelle'],
-                 'name:alt': row['Haltestelle_lang']}
+        lat = float(row['zhv_lat'])
+        lon = float(row['zhv_lon'])
+        address = {addr_type: row[row_name]
+                   for row_name, addr_type in ADDRESS_MAPPING if row.get(row_name)}
         extratags = {'ref:IFOPT' : ifopt}
 
         if ifopt in extra_ifopts:
             update_artificial(conn, extra_ifopts[ifopt],
-                              names, address, extratags, lon, lat)
+                              names, address, extratags, lon, lat, invalidate)
             external_updated += 1
 
         else:
@@ -218,7 +241,7 @@ def import_pt(conn, csvfile, invalidate):
         print(f"Deleted external: {len(to_delete)}")
 
 
-if __name__ == '__main__':
+def main():
     parser = get_parser()
     args = parser.parse_args()
 
@@ -228,15 +251,19 @@ if __name__ == '__main__':
                         datefmt='%Y-%m-%d %H:%M:%S',
                         level=max(3 - args.verbose, 1) * 10)
 
-    conn = connect(args)
+    with psycopg.connect(dbname=args.database, user=args.username,
+                         host=args.host, port=args.port, password=args.password) as conn:
+        info = psycopg.types.TypeInfo.fetch(conn, "hstore")
+        psycopg.types.hstore.register_hstore(info, conn)
 
-    if args.infile.endswith('.gz'):
-        with gzip.open(args.infile, 'rt') as csvfile:
-            ret = import_pt(conn, csvfile, args.invalidate)
-    else:
-        with open(args.infile, newline='') as csvfile:
-            ret = import_pt(conn, csvfile, args.invalidate)
-    conn.commit()
-    conn.close()
+        if args.infile.endswith('.gz'):
+            ctx = gzip.open(args.infile, 'rt')
+        else:
+            ctx = open(args.infile, newline='')
 
-    sys.exit(ret)
+        with ctx as csvfile:
+            return import_pt(conn, csvfile, args.invalidate)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/roles/photon/templates/update-nominatim
+++ b/roles/photon/templates/update-nominatim
@@ -1,12 +1,14 @@
 #! /bin/bash -e
 
-docker exec -i nominatim sudo -u nominatim nominatim replication --project-dir /nominatim --once --no-index
+docker exec -i nominatim sudo -u nominatim nominatim replication --project-dir /nominatim --once
 
-OUTPUT_FILE=nvbw_osm_matches.csv
+OUTPUT_FILE=nvbw_osm_matches.csv.gz
 
-curl -o - https://data.mfdz.de/mfdz/nvbw_osm_matches.csv.gz | gunzip > ${OUTPUT_FILE}
+curl -o ${OUTPUT_FILE} https://data.mfdz.de/mfdz/nvbw_osm_matches.csv.gz
 echo "Downloaded station matches to ${OUTPUT_FILE}"
 
 echo "Re-adding IFOPTs"
 echo "...finished"
 ./nominatim_add_ifopt.py --username nominatim --host localhost --port 5432 --password {{ nominatim_db_password }} ${OUTPUT_FILE}
+
+docker exec -i nominatim sudo -u nominatim nominatim index


### PR DESCRIPTION
Updates the IFOPT update script for recent versions of Photon. This includes some fixes and improvements:

* update to recent psycopg3
* make imported address columns optional and configurable
* copy names from IFOPT data into Nominatim database when Nominatim does not have a name
* fix issue where IFOPT was not set when Nominatim does not have any extratags yet
* be more clever about marking data as changed (no need for the '-i' flag anymore)
* increase the minimum ID for external data (hopefully now works for more than a year)
* allow to skip CSV lines according to match_state
* do not set name and alt_name from IFOPT data when they are the same

Running against the current DELFI CSV, I get:

```
Matched: 390737, updated: 0, added: 77022
```

Please note that the update method of Photon has changed. You must set up Photon for updates with `-nominatim-update-init-for` before running the script. I've updated the `update-nominatim` script to follow the new steps for running updates.

Further note that I have updated the name of the 'GlobaleID' column in the CSV which likely means the script cannot be run against the NVBW data anymore.