### PR TITLE
Configure vvs alerts feed to translated feed

### DIFF
--- a/roles/digitransit/templates/otp/herrenberg/router-config.json
+++ b/roles/digitransit/templates/otp/herrenberg/router-config.json
@@ -126,8 +126,11 @@
     },
     {
       "type": "real-time-alerts",
-      "url": "https://gtfsr-servicealerts.vvs.de/",
-      "feedId": "hbg"
+      "url": "https://data.mfdz.de/vvs_gtfsrt_alerts_herrenberg/body.pbf",
+      "feedId": "hbg",
+      "headers": {
+        "User-Agent": "OpenTripPlanner (stadtnavi hbg)"
+      }
     },
     {
       "type": "vehicle-positions",


### PR DESCRIPTION
This PR switches the VVS gtfs-rt service-alerts feed to a transformed version.

See #64 and https://github.com/mfdz/gtfs-realtime-translators/pull/1 for the necessity.