### PR TITLE
Switch photon to photon-eu for dev

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -70,7 +70,7 @@ digitransit_port: 8080
 digitransit_static_message_url: /assets/messages/message.hb.json
 
 photon_hostname: photon.stadtnavi.eu
-photon_new_hostname: photon-new.stadtnavi.eu
+photon_new_hostname: photon-eu.stadtnavi.eu
 photon_url: https://{{ photon_hostname }}
 
 additional_users: []

--- a/group_vars/dev.yml
+++ b/group_vars/dev.yml
@@ -27,6 +27,8 @@ delay_prediction_service_version: latest
 api_hostname: api.dev.stadtnavi.eu
 dt_api_hostname: "{{api_hostname}}"
 
+photon_url: https://{{ photon_new_hostname }}
+
 matomo_hostname: track.dev.stadtnavi.eu
 matomo_url: https://track.dev.stadtnavi.eu/js/container_T70NE3DF.js
 


### PR DESCRIPTION
This PR switches to `photon-eu.stadtnavi.eu` for the dev instance.
