### PR TITLE
config: switch ocpdb service from ocpdb.de to mobidata-bw

### DIFF
--- a/roles/services/templates/nginx-site.conf
+++ b/roles/services/templates/nginx-site.conf
@@ -32,17 +32,17 @@ server {
     proxy_cache_valid   200 1m;
     proxy_buffering     off;
 
-    rewrite /tiles/charging-stations/(.*) /tiles/$1  break;
-    proxy_pass https://api.ocpdb.de;
+    rewrite /tiles/charging-stations/(.*) /ocpdb/tiles/$1  break;
+    proxy_pass https://api.mobidata-bw.de;
   }
 
-  location ~ ^/ocpi/(.*)$ {
+  location ~ ^/ocpi/2.2/location/(.*)$ {
       proxy_cache         charging-stations;
       proxy_cache_valid   200 1m;
       proxy_buffering     off;
 
-      proxy_pass https://api.ocpdb.de/api/ocpi/$1;
-    }
+      proxy_pass https://api.mobidata-bw.de/ocpdb/api/public/v1/locations/$1;
+  }
 
   # widget
   location ~* ^/widget/(.*)$ {


### PR DESCRIPTION
This PR switches ocpdb tiles and locations endpoints to MobiData BW, as MobiData BW now provides this service and works hard to get additional operators to share their data.

I.e. the endpoint name for `ocpi/2.2/location` changed. The response is mostly equivalent, the minimal changes have been done to become fully OCPI compliant and are irrelevant to the digitransit client:

* `location.uid` and `connector.uid`  have been removed
* former `evse.uid` has been renamed to `evse.evse_id`

Fixes stadtnavi/digitranit-ui#960

