### PR TITLE
chore: bump thingsboard-to-parkapi version

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -80,7 +80,7 @@ additional_users: []
 # one week
 docker_prune_max_age: 168h
 
-thingsboard_to_parkapi_commit: 9a29c2842636ee9b3b684e34068b1343ac989653
+thingsboard_to_parkapi_commit: 4fa338eadd72b7cf16f8e1cf7f47b52871789ea5
 thingsboard_enhancer_commit: 4f589b3359fdda3361242969830cb0a5212ab913
 thingsboard_to_mqtt_version: abfbca97df0bcaa1c14a89cbe9dbdebcde7b3816
 


### PR DESCRIPTION
This PR bumps the thingsboard-to-parkapi version to https://github.com/mfdz/thingsboard-to-parkapi/commit/4fa338eadd72b7cf16f8e1cf7f47b52871789ea5.

This fixes https://github.com/stadtnavi/digitransit-ui/issues/966