### PR TITLE
Chore: switch cargo bikes GBFS source to mobidata

### DIFF
--- a/roles/digitransit/templates/otp/herrenberg/router-config.json
+++ b/roles/digitransit/templates/otp/herrenberg/router-config.json
@@ -162,25 +162,37 @@
       "type": "bike-rental",
       "frequency": "15m",
       "sourceType": "gbfs",
-      "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/alf/gbfs.json"
+      "url": "https://api.mobidata-bw.de/sharing/gbfs/v2/herrenberg_alf/gbfs",
+      "headers": {
+        "User-Agent": "OpenTripPlanner (stadtnavi hbg)"
+      }
     },
     {
       "type": "bike-rental",
       "frequency": "15m",
       "sourceType": "gbfs",
-      "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/gueltstein-mobil/gbfs.json"
+      "url": "https://api.mobidata-bw.de/sharing/gbfs/v2/herrenberg_guelf/gbfs",
+      "headers": {
+        "User-Agent": "OpenTripPlanner (stadtnavi hbg)"
+      }
     },
     {
       "type": "bike-rental",
       "frequency": "15m",
       "sourceType": "gbfs",
-      "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/bananologen/gbfs.json"
+      "url": "https://api.mobidata-bw.de/sharing/gbfs/v2/herrenberg_fare/gbfs",
+      "headers": {
+        "User-Agent": "OpenTripPlanner (stadtnavi hbg)"
+      }
     },
     {
       "type": "bike-rental",
       "frequency": "15m",
       "sourceType": "gbfs",
-      "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/stadtrad/gbfs.json"
+      "url": "https://api.mobidata-bw.de/sharing/gbfs/v2/herrenberg_stadtrad/gbfs",
+      "headers": {
+        "User-Agent": "OpenTripPlanner (stadtnavi hbg)"
+      }
     },
     {
       "type": "bike-rental",
@@ -350,30 +362,11 @@
         "User-Agent": "OpenTripPlanner (stadtnavi hbg)"
       }
     },
-    {% if enable_fake_bike_box -%}
-    {
-      "type": "vehicle-parking",
-      "sourceType": "bicycle-park-api",
-      "frequency": "10m",
-      "feedId": "open-bike-box",
-      "url": "https://api.dev.stadtnavi.eu/herrenberg/parking/open-bike-box.json",
-      "tags": ["bike-locker"],
-      "timeZone": "Europe/Berlin"
-    },
-    {% endif %}
     {
       "type": "vehicle-parking",
       "sourceType": "park-api",
       "feedId": "park-api",
       "url": "https://{{ api_hostname }}/herrenberg/parking/parkapi.json",
-      "timeZone": "Europe/Berlin"
-    },
-    {
-      "type": "vehicle-parking",
-      "sourceType": "park-api",
-      "frequency": "10m",
-      "feedId": "park-api-rt",
-      "url": "https://{{ api_hostname }}/kreis_reutlingen/parking/parkapi.json",
       "timeZone": "Europe/Berlin"
     },
     {

--- a/roles/digitransit/templates/otp/herrenberg/router-config.json
+++ b/roles/digitransit/templates/otp/herrenberg/router-config.json
@@ -206,6 +206,15 @@
     {
       "type": "bike-rental",
       "sourceType": "gbfs",
+      "url": "https://api.mobidata-bw.de/sharing/gbfs/v2/lime_stuttgart/gbfs",
+      "allowKeepingRentedVehicleAtDestination": true,
+      "headers": {
+        "User-Agent": "OpenTripPlanner (stadtnavi hbg)"
+      }
+    },
+    {
+      "type": "bike-rental",
+      "sourceType": "gbfs",
       "url": "https://api.mobidata-bw.de/sharing/gbfs/zeus_pforzheim/gbfs",
       "headers": {
         "User-Agent": "OpenTripPlanner (stadtnavi hbg)"


### PR DESCRIPTION
This PR switches the source for Herrenberg cargo bike feeds to MobiData-BW.

Note: in consequence, the feed_ids change and need to be adapted in the UI/App.

Besides this, this PR adds GBFS feed for Lime Scooters in Stuttgart